### PR TITLE
Fix package name of Chrome in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Debian 中文社区软件源列表说明
       - 否
       - N/A
       - 从 sid 移植
-    * - chrome
+    * - google-chrome-stable
       - Google Chrome
       - 否
       - stretch, sid


### PR DESCRIPTION
中午用上了这个 Repo，直到刚才才意识到 Chrome 的包名是 `google-chrome-stable` 不是 `chrome`。